### PR TITLE
Upgrade packages, switch to caret versioning

### DIFF
--- a/darwin-libproc/Cargo.toml
+++ b/darwin-libproc/Cargo.toml
@@ -16,5 +16,5 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 darwin-libproc-sys = { version = "0.2", path = "../darwin-libproc-sys" }
-libc = "~0.2"
-memchr = "~2.3"
+libc = "^0.2"
+memchr = "^2.4"


### PR DESCRIPTION
I've been running into problems updating some of my workspaces using
Heim, I believe due to memchr being a couple of versions behind. This PR
fixes that and switches to caret versioning to match the changes done in
heim-rs/heim.